### PR TITLE
Object Refactoring

### DIFF
--- a/live-cache.js
+++ b/live-cache.js
@@ -3,46 +3,57 @@
  */
 
 
-var Live_Cache = {
-	ajaxurl: Live_Cache.ajaxurl, /*value originally set by localize script*/
-	values: [],
-	callbacks: [],
-	timeStamp: 1,
-	timer: setInterval(function(){Live_Cache.check();},6000),
-	getValue: function (key) {
+function Live_Cache_Obj() {
+	var self = this,
+		ajaxurl = Live_Cache.ajaxurl, // Value originally set by localize script
+		values = [],
+		callbacks = [],
+		timeStamp = 1;
+
+	this.timer = setInterval(function () {
+		Live_Cache.check();
+	}, 6000);
+
+	this.getValue = function (key) {
 		// if it has been more than 60 sec by local clock
-			this.check();
-		return (typeof this.values[key]!=="undefined") ? this.values[key] : false;
-	},
-	setCallback: function (key, callback ) {
-		if (typeof this.callbacks[key]=="undefined") 
-			this.callbacks[key] = jQuery.Callbacks( "unique" );
-		this.callbacks[key].add(callback);
-	},
-	check: function () {
+		self.check();
+		return (typeof values[key] !== "undefined") ? values[key] : false;
+	};
+
+	this.setCallback = function (key, callback ) {
+		if (typeof callbacks[key] == "undefined") {
+			callbacks[key] = jQuery.Callbacks( "unique" );
+		}
+		callbacks[key].add(callback);
+	};
+
+	this.check = function () {
 		jQuery.get(
-			Live_Cache.ajaxurl,
-			{ "live_cache_check": this.timeStamp },
-			function(data,s,resp){
+			ajaxurl,
+			{ "live_cache_check": timeStamp },
+			function (data, s, resp) {
 				var time = resp.getResponseHeader('Date').split(" ")[4];
 				console.log(time);
-				Live_Cache.timeStamp = time.substr(0,2)+time.substr(3,2)+time.substr(6,1);
+				timeStamp = time.substr(0,2) + time.substr(3,2) + time.substr(6,1);
 				jQuery.each(data, function(key, value) {
-					if ( typeof Live_Cache.callbacks[key]!=="undefined" && (typeof Live_Cache.values[key]=="undefined" || Live_Cache.values[key]!==value) ){
-						Live_Cache.callbacks[key].fire(value);
+					if ( typeof callbacks[key] !== "undefined" && (typeof values[key] == "undefined" || values[key] !== value) ){
+						callbacks[key].fire(value);
 					}
 				});
-				Live_Cache.values = data;
+				values = data;
 			},
 			"json"
 		);
-	}
+	};
 }
 
 /*
  * Use our own system reset our timer if the refresh rate has been updated
  */
-Live_Cache.setCallback('refresh_rate', function(value){
+var Live_Cache = new Live_Cache_Obj();
+Live_Cache.setCallback('refresh_rate', function (value) {
 	clearInterval(Live_Cache.timer);
-	Live_Cache.timer=setInterval(function(){Live_Cache.check();},value*1000);
+	Live_Cache.timer = setInterval(function () {
+		Live_Cache.check();
+	}, value * 1000);
 });


### PR DESCRIPTION
The `Live_Cache` object has been converted into a function that can instantiate an object, called `Live_Cache_Obj()`.  To instantiate, just set `var Live_Cache = new Live_Cache_Obj()`.

This new version of the object has both private and public variables.  Private variables are contained within the object's closure scope and defined with `var` inside the object.  Public variables are defined as `this.variable_or_method_name`.

Private variables can, obviously, only be used within the object itself.  Since they're in the object's scope, they can even be referenced inside local callbacks like within the `jQuery.get()` return.

Public variables/methods can be referenced externally as `Live_cache.check()`.  Internally they're referenced as `self.check()` since `self` maintains a reference to the original scope of the object upon its instantiation.
